### PR TITLE
Update initialize.ts

### DIFF
--- a/src/config/initialize.ts
+++ b/src/config/initialize.ts
@@ -9,7 +9,7 @@ export const initializeTransactionData = (
     const tx: TransactionData = {
         swap: {},
         isSwap: markets[recipient].name === 'NFT Trader 🔄',
-        isSweep: markets[recipient].name === 'Gem 💎' || markets[recipient].name === 'Genie 🧞‍♂️',
+        isSweep: false,
         isSudo: markets[recipient].name === 'Sudoswap',
         tokens: [],
         prices: [],

--- a/test/integration/erc1155.saleEvent.test.ts
+++ b/test/integration/erc1155.saleEvent.test.ts
@@ -30,6 +30,7 @@ describe('ERC 1155 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.fromAddr ?? '')).to.be.true;
@@ -49,6 +50,7 @@ describe('ERC 1155 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.fromAddr ?? '')).to.be.true;
@@ -68,6 +70,7 @@ describe('ERC 1155 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,true);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.sweeperAddr ?? '')).to.be.true;
@@ -86,6 +89,7 @@ describe('ERC 1155 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.sweeperAddr ?? '')).to.be.true;

--- a/test/integration/erc721.saleEvent.test.ts
+++ b/test/integration/erc721.saleEvent.test.ts
@@ -32,6 +32,7 @@ describe('ERC 721 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.fromAddr ?? '')).to.be.true;
@@ -53,6 +54,7 @@ describe('ERC 721 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.fromAddr ?? '')).to.be.true;
@@ -74,6 +76,7 @@ describe('ERC 721 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.fromAddr ?? '')).to.be.true;
@@ -94,6 +97,7 @@ describe('ERC 721 Integration Test', function () {
 
             if (!tx) return;
 
+            assert.strictEqual(tx.isSweep,true);
             assert.strictEqual(tx.tokens.length, 2);
             assert.strictEqual(tx.prices.length, 1);
             assert.strictEqual(tx.prices[0], '0.10');
@@ -120,6 +124,7 @@ describe('ERC 721 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,true);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.sweeperAddr ?? '')).to.be.true;
@@ -140,6 +145,7 @@ describe('ERC 721 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,true);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.sweeperAddr ?? '')).to.be.true;
@@ -160,6 +166,7 @@ describe('ERC 721 Integration Test', function () {
             const isSameSize =
                 tx.tokens.length === tx.prices.length && tx.tokens.length === tx.marketList.length;
 
+            assert.strictEqual(tx.isSweep,true);
             expect(isSameSize).to.be.true;
             expect(tx.tokenData).to.not.be.null;
             expect(ethers.utils.isAddress(tx.sweeperAddr ?? '')).to.be.true;

--- a/test/integration/sudoswap.test.ts
+++ b/test/integration/sudoswap.test.ts
@@ -17,6 +17,7 @@ describe('Sudoswap Integration Test', function () {
 
             const isSameSize = tx.tokens.length === tx.quantity;
 
+            assert.strictEqual(tx.isSweep,true);
             expect(isSameSize).to.be.true;
             expect(tx.isSudo).to.be.true;
             expect(tx.tokenData).to.not.be.null;
@@ -39,6 +40,7 @@ describe('Sudoswap Integration Test', function () {
 
             const isSameSize = tx.tokens.length === tx.quantity;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.isSudo).to.be.true;
             expect(tx.tokenData).to.not.be.null;
@@ -61,6 +63,7 @@ describe('Sudoswap Integration Test', function () {
 
             const isSameSize = tx.tokens.length === tx.quantity;
 
+            assert.strictEqual(tx.isSweep,false);
             expect(isSameSize).to.be.true;
             expect(tx.isSudo).to.be.true;
             expect(tx.tokenData).to.not.be.null;


### PR DESCRIPTION
sweep should be false by default in `initialize.ts` because you can use Gem to buy 1 NFT, causing the GIF generation logic to fail if sweep is on by default

I added checking to see if `isSweep` was true or false in the integration tests as well