### PR TITLE
enhancement: parseSudoswap.ts

### DIFF
--- a/src/controllers/parseSudoswap.ts
+++ b/src/controllers/parseSudoswap.ts
@@ -12,6 +12,8 @@ export async function parseSudoswap(tx: TransactionData) {
 
     if (functionName === 'swapETHForSpecificNFTs') {
         tx.totalPrice = Number(ethers.utils.formatEther(transaction.value.toString()));
+    } else if (functionName === 'robustSwapETHForSpecificNFTs'){
+        tx.totalPrice = Number(ethers.utils.formatEther(transaction.value.toString()));
     } else if (functionName === 'robustSwapNFTsForToken') {
         tx.totalPrice = Number(
             ethers.utils.formatEther(parsedTxn.args.swapList[0].minOutput.toString())


### PR DESCRIPTION
I caught a transaction type not being processed `robustSwapETHForSpecificNFTs` tested it against a live transaction and it works 0x98694c9db3066a0831a5d5438e965eb58f34ea197d6ded3dc070d592d2fd0967